### PR TITLE
Set date input range min (14 days ago) and max (today)

### DIFF
--- a/A.html
+++ b/A.html
@@ -155,7 +155,7 @@
 
     <script src="scripts/main.js"></script>
 	<script type="text/javascript">document.onload = changeTextA()</script>
-	
+	<script type="text/javascript">document.onload = setDateMinMax()</script>
 </body>
 
 </html>

--- a/N.html
+++ b/N.html
@@ -135,7 +135,7 @@
 
     <script src="scripts/main.js"></script>
 	<script type="text/javascript">document.onload = changeTextN()</script>
-	
+	<script type="text/javascript">document.onload = setDateMinMax()</script>
 </body>
 
 </html>

--- a/P.html
+++ b/P.html
@@ -162,7 +162,7 @@
 
     <script src="scripts/main.js"></script>
 	<script type="text/javascript">document.onload = changeTextP()</script>
-	
+	<script type="text/javascript">document.onload = setDateMinMax()</script>
 </body>
 
 </html>

--- a/R.html
+++ b/R.html
@@ -155,7 +155,7 @@
 
     <script src="scripts/main.js"></script>
 	<script type="text/javascript">document.onload = changeTextR()</script>
-	
+	<script type="text/javascript">document.onload = setDateMinMax()</script>
 </body>
 
 </html>

--- a/S.html
+++ b/S.html
@@ -178,6 +178,7 @@
 
     <script src="scripts/main.js"></script>
 	<script type="text/javascript">document.onload = changeTextS()</script>
+	<script type="text/javascript">document.onload = setDateMinMax()</script>
 </body>
 
 </html>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -40,6 +40,24 @@ function formatDate(date) {
     return [day,month,year].join('.');
 }
 
+function setDateMinMax() {
+	var now = new Date();
+	var max = now.toISOString().substring(0,10)
+
+	var minDate=new Date()
+	minDate.setDate(minDate.getDate()-14)
+	var min = minDate.toISOString().substring(0,10);
+
+	var inputs = document.getElementsByTagName("input");
+	for (const i of inputs) {
+		if (i.getAttribute("type")!='date')
+			continue;
+
+		i.setAttribute('min', min )
+		i.setAttribute('max', max )
+	}
+}
+
 function AdujstTxtGender(text, word, wordm, wordf) {
 	var checkBoxM = document.getElementById("male");
 	var checkBoxF = document.getElementById("female");


### PR DESCRIPTION
Set the valid date inputs range `min` and `max` attributes to help the user by limiting his choices
![image](https://user-images.githubusercontent.com/319826/103148655-64e49080-4762-11eb-9ac8-b7dece570c80.png)

14 day min may be too strict in some cases, should be reviewed and then we can
- make exceptions in some cases if needed 
- extend to eg 21 days globally
- leave as it is (earliest valid date is 14 days ago)

We could also remove the current default dates to make sure users enter it on their own, but that would require a bit more checks to avoid sending messages with invalid dates containing `NaN`s 😄 